### PR TITLE
Use env var at runtime for async mode

### DIFF
--- a/src/audible/core/ai.py
+++ b/src/audible/core/ai.py
@@ -37,7 +37,8 @@ def call_llm_api(prompt, system_message=None, model=None, temperature=0.0,
     provider = provider or DEFAULT_LLM_PROVIDER
 
     # Check if async should be used
-    use_async = USE_ASYNC if use_async is None else use_async
+    if use_async is None:
+        use_async = os.getenv("AUDIBLE_USE_ASYNC", "false").lower() == "true"
 
     # If async is requested, use async call via event loop
     if use_async:


### PR DESCRIPTION
## Summary
- check AUDIBLE_USE_ASYNC on each call to `call_llm_api`

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_682a20763dcc832c93295fcca9a87457