### PR TITLE
Add result assertion to OpenAI TTS test

### DIFF
--- a/tests/integration/test_audio_generation_openai.py
+++ b/tests/integration/test_audio_generation_openai.py
@@ -132,6 +132,8 @@ def test_generate_audio_openai(temp_test_book_dir, mock_openai_tts, mock_ffmpeg,
         use_async=False # Test sync path first
     )
 
+    assert result is True
+
     # --- Verification ---
     # Actual chapter directory is in the audio/provider/chapter_1 format
     audio_provider_dir = os.path.join(book_dir, "audio", tts_provider)


### PR DESCRIPTION
## Summary
- ensure `process_tts_files` returns `True` in OpenAI integration test

## Testing
- `pytest -q` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_682a2085e664832c853547bf05a41fa1