### PR TITLE
Update Google TTS default model

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,7 +313,7 @@ After generating the default voice mappings, you can customize them by editing t
   "Narrator": {
     "openai": "onyx",
     "cartesia": "0123456789abcdef0123456789abcdef",
-    "google": "en-US-Neural2-D"
+    "google": "gemini-2.5-pro-preview-tts"
   },
   "Character Name": {
     "openai": "nova",

--- a/src/audible/tts/google_tts.py
+++ b/src/audible/tts/google_tts.py
@@ -11,7 +11,7 @@ from audible.utils.common import log
 class GoogleTTS:
     """Class for interacting with Google Cloud text-to-speech API."""
 
-    def __init__(self, model="en-US-Neural2-D"):
+    def __init__(self, model="gemini-2.5-pro-preview-tts"):
         """
         Initialize Google Cloud TTS provider.
 

--- a/src/audible/tts/tts_factory.py
+++ b/src/audible/tts/tts_factory.py
@@ -33,7 +33,7 @@ class TTSFactory:
                 model = "sonic-2"  # Default Cartesia TTS model
             elif provider == "google":
                 from audible.tts.google_tts import GoogleTTS
-                model = "en-US-Neural2-D"  # Default Google TTS model
+                model = "gemini-2.5-pro-preview-tts"  # Default Google TTS model
             elif provider == "csm":
                 from audible.tts.csm_tts import CSMTTS
                 model = "csm-1b"  # Default CSM TTS model


### PR DESCRIPTION
## Summary
- update GoogleTTS default model to `gemini-2.5-pro-preview-tts`
- adjust TTS factory
- update README example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'tiktoken')*

------
https://chatgpt.com/codex/tasks/task_e_6841dea88958832ca010fbf34b58113d